### PR TITLE
feat: Prevent duplicate demo requests

### DIFF
--- a/backend/controllers/projectController.js
+++ b/backend/controllers/projectController.js
@@ -462,6 +462,10 @@ const deleteProject = async (req, res) => {
 const createDemoRequest = async (req, res) => {
     const { projectId, fullName, emailAddress, requestDate, requestTime, comments } = req.body;
     try {
+        const checkUser = await pool.query('SELECT * FROM DemoRequest WHERE emailAddress = $1 AND projectId = $2', [emailAddress, projectId]);
+        if (checkUser.rows.length > 0) {
+            return res.status(409).json({ error: 'You have already requested a demo for this project' });
+        }
         const result = await pool.query(
             'INSERT INTO DemoRequest (projectId, fullName, emailAddress, requestDate, requestTime, comments) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
             [projectId, fullName, emailAddress, requestDate, requestTime, comments]

--- a/backend/docs/projectDocs.js
+++ b/backend/docs/projectDocs.js
@@ -469,6 +469,8 @@
  *     responses:
  *       201:
  *         description: Demo request created successfully
+ *       409:
+ *         description: User has made a demo request for this project before
  *       500:
  *         description: Internal server error
  *   get:


### PR DESCRIPTION
Prevent users from submitting multiple demo requests for the same project by checking if they have already made a request before inserting a new record into the database.

Fixes #123